### PR TITLE
Added ability to define app name, author, price and icon via the meta tag

### DIFF
--- a/jquery.smartbanner.js
+++ b/jquery.smartbanner.js
@@ -38,6 +38,7 @@
         this.title = this.options.title ? this.options.title : meta.data('title') || $('title').text().replace(/\s*[|\-·].*$/, '')
         this.author = this.options.author ? this.options.author : meta.data('author') || ($('meta[name="author"]').length ? $('meta[name="author"]').attr('content') : window.location.hostname)
         this.iconUrl = meta.data('icon-url');
+        this.price = meta.data('price');
 
         // Create banner
         this.create()
@@ -52,7 +53,8 @@
       , create: function() {
             var iconURL
               , link=(this.options.url ? this.options.url : (this.type=='android' ? 'market://details?id=' : ('https://itunes.apple.com/' + this.options.appStoreLanguage + '/app/id')) + this.appId)
-              , inStore=this.options.price ? this.options.price + ' - ' + (this.type=='android' ? this.options.inGooglePlay : this.options.inAppStore) : ''
+              , price = this.price || this.options.price
+              , inStore = price ? price + ' - ' + (this.type=='android' ? this.options.inGooglePlay : this.options.inAppStore) : ''
               , gloss=this.options.iconGloss === null ? (this.type=='ios') : this.options.iconGloss
 
             $('body').append('<div id="smartbanner" class="'+this.type+'"><div class="sb-container"><a href="#" class="sb-close">&times;</a><span class="sb-icon"></span><div class="sb-info"><strong>'+this.title+'</strong><span>'+this.author+'</span><span>'+inStore+'</span></div><a href="'+link+'" class="sb-button"><span>'+this.options.button+'</span></a></div></div>')


### PR DESCRIPTION
This allows developers to add data- attributes to the meta tag to populate title, author, price and icon. I've added the checks between the options hash and checking the other items on the page.

Example: 

```
<meta content="app-id=org.example.app" data-author="Author Name" data-icon="/path/to/icon.png" data-title="Example App" name="google-play-app" />
```
