### PR TITLE
adding iOS like slideIn effect for banner

### DIFF
--- a/jquery.smartbanner.js
+++ b/jquery.smartbanner.js
@@ -54,8 +54,9 @@
               , inStore=this.options.price ? this.options.price + ' - ' + (this.type=='android' ? this.options.inGooglePlay : this.options.inAppStore) : ''
               , gloss=this.options.iconGloss === null ? (this.type=='ios') : this.options.iconGloss
 
-            $('body').append('<div id="smartbanner" class="'+this.type+'"><div class="sb-container"><a href="#" class="sb-close">&times;</a><span class="sb-icon"></span><div class="sb-info"><strong>'+this.title+'</strong><span>'+this.author+'</span><span>'+inStore+'</span></div><a href="'+link+'" class="sb-button"><span>'+this.options.button+'</span></a></div></div>')
-            
+            var banner = '<div id="smartbanner" class="'+this.type+'"><div class="sb-container"><a href="#" class="sb-close">&times;</a><span class="sb-icon"></span><div class="sb-info"><strong>'+this.title+'</strong><span>'+this.author+'</span><span>'+inStore+'</span></div><a href="'+link+'" class="sb-button"><span>'+this.options.button+'</span></a></div></div>';
+            (this.options.layer) ? $('body').append(banner) : $('body').prepend(banner);
+
             if (this.options.icon) {
                 iconURL = this.options.icon
             } else if ($('link[rel="apple-touch-icon-precomposed"]').length > 0) {
@@ -77,12 +78,14 @@
                 $('#smartbanner')
                     .css('top', parseFloat($('#smartbanner').css('top')) * this.scale)
                     .css('height', parseFloat($('#smartbanner').css('height')) * this.scale)
+                    .hide()
                 $('#smartbanner .sb-container')
                     .css('-webkit-transform', 'scale('+this.scale+')')
                     .css('-msie-transform', 'scale('+this.scale+')')
                     .css('-moz-transform', 'scale('+this.scale+')')
                     .css('width', $(window).width() / this.scale)
             }
+            $('#smartbanner').css('position', (this.options.layer) ? 'absolute' : 'static')
         }
         
       , listen: function () {
@@ -90,14 +93,26 @@
             $('#smartbanner .sb-button').on('click',$.proxy(this.install, this))
         }
         
-      , show: function(callback) {
-            $('#smartbanner').stop().animate({top:0},this.options.speedIn).addClass('shown')
-            $('html').animate({marginTop:this.origHtmlMargin+(this.bannerHeight*this.scale)},this.options.speedIn,'swing',callback)
+      , show: function (callback) {
+            var banner = $('#smartbanner');
+            banner.stop();
+            if (this.options.layer) {
+                banner.animate({top: 0, display: 'block'}, this.options.speedIn).addClass('shown').show();
+                $('html').animate({marginTop: this.origHtmlMargin + (this.bannerHeight * this.scale)}, this.options.speedIn, 'swing', callback);
+            } else {
+                banner.slideDown(this.options.speedIn).addClass('shown');
+            }
         }
         
-      , hide: function(callback) {
-            $('#smartbanner').stop().animate({top:-1*this.bannerHeight*this.scale},this.options.speedOut).removeClass('shown')
-            $('html').animate({marginTop:this.origHtmlMargin},this.options.speedOut,'swing',callback)
+      , hide: function (callback) {
+            var banner = $('#smartbanner');
+            banner.stop();
+            if (this.options.layer) {
+                banner.animate({top: -1 * this.bannerHeight * this.scale}, this.options.speedOut).removeClass('shown').hide();
+                $('html').animate({marginTop: this.origHtmlMargin}, this.options.speedOut, 'swing', callback);
+            } else {
+                banner.slideUp(this.options.speedOut).removeClass('shown');
+            }
         }
       
       , close: function(e) {
@@ -114,7 +129,7 @@
       , setCookie: function(name, value, exdays) {
             var exdate = new Date()
             exdate.setDate(exdate.getDate()+exdays)
-            value=escape(value)+((exdays==null)?'':'; expires='+exdate.toUTCString())
+            value=encodeURI(value)+((exdays==null)?'':'; expires='+exdate.toUTCString())
             document.cookie=name+'='+value+'; path=/;'
         }
         
@@ -125,7 +140,7 @@
                 y = ARRcookies[i].substr(ARRcookies[i].indexOf("=")+1)
                 x = x.replace(/^\s+|\s+$/g,"")
                 if (x==name) {
-                    return unescape(y)
+                    return decodeURI(y)
                 }
             }
             return null
@@ -172,7 +187,8 @@
         speedOut: 400, // Close animation speed of the banner
         daysHidden: 15, // Duration to hide the banner after being closed (0 = always show banner)
         daysReminder: 90, // Duration to hide the banner after "VIEW" is clicked *separate from when the close button is clicked* (0 = always show banner)
-        force: null // Choose 'ios' or 'android'. Don't do a browser check, just always show this banner
+        force: null, // Choose 'ios' or 'android'. Don't do a browser check, just always show this banner
+        layer: false // Display as overlay layer or slide down the page
     }
     
     $.smartbanner.Constructor = SmartBanner


### PR DESCRIPTION
I had a usecase where the overlaying style was very uncomfortable, cause it hides important controls.
So i copied the native iOS behaviour to slide down the page to show the smartbanner.

To control this behaviour there is a additional option 'layer':boolean.

This has to main impacts:
- the javascript code set the position rather than only the css code, cause the slide cannot work with absolute positioning
- the initial smartbanner will be hidden (display:none / jQuery.hide())

In addition i replaced unescape and ecapse, cause those function are considered deprecated.

I hope somebody enjoys the feature - thx and keep on the n1ce work =]
