### PR TITLE
Added option to show banner to iPad users if the App is a universal app

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ brings this feature to older iOS versions, Android devices and for Windows Store
       daysHidden: 15, // Duration to hide the banner after being closed (0 = always show banner)
       daysReminder: 90, // Duration to hide the banner after "VIEW" is clicked *separate from when the close button is clicked* (0 = always show banner)
       force: null // Choose 'ios', 'android' or 'windows'. Don't do a browser check, just always show this banner
+      iOSUniversalApp: true // If the iOS App is a universal app for both iPad and iPhone, display Smart Banner to iPad users, too.      
     })
 
   [1]: http://developer.apple.com/library/ios/#documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html

--- a/jquery.smartbanner.js
+++ b/jquery.smartbanner.js
@@ -13,7 +13,7 @@
         // Detect banner type (iOS or Android)
         if (this.options.force) {
             this.type = this.options.force
-        } else if (navigator.userAgent.match(/iPad|iPhone|iPod/i) != null) {
+        } else if (navigator.userAgent.match(/iPhone|iPod/i) != null || (navigator.userAgent.match(/iPad/) && this.options.iOSUniversalApp)) {
             if (navigator.userAgent.match(/Safari/i) != null &&
                (navigator.userAgent.match(/CriOS/i) != null ||
                window.Number(navigator.userAgent.substr(navigator.userAgent.indexOf('OS ') + 3, 3).replace('_', '.')) < 6)) this.type = 'ios' // Check webview and native smart banner support (iOS 6+)
@@ -188,7 +188,8 @@
         speedOut: 400, // Close animation speed of the banner
         daysHidden: 15, // Duration to hide the banner after being closed (0 = always show banner)
         daysReminder: 90, // Duration to hide the banner after "VIEW" is clicked *separate from when the close button is clicked* (0 = always show banner)
-        force: null // Choose 'ios', 'android' or 'windows'. Don't do a browser check, just always show this banner
+        force: null, // Choose 'ios', 'android' or 'windows'. Don't do a browser check, just always show this banner
+        iOSUniversalApp: true // If the iOS App is a universal app for both iPad and iPhone, display Smart Banner to iPad users, too.
     }
 
     $.smartbanner.Constructor = SmartBanner


### PR DESCRIPTION
When using the smartbanners on iOS, it is often not a good user experience to direct the users to an iPhone app when they are viewing the website on their iPad. With this additional configuration option it is possible to show the smartbanners only if the iOS app is a universal app that is optimized for iPad, too.
