### PR TITLE
Test regex result before accessing by index

### DIFF
--- a/jquery.smartbanner.js
+++ b/jquery.smartbanner.js
@@ -46,7 +46,14 @@
             this.pfn = $('meta[name="msApplication-PackageFamilyName"]').attr('content');
             this.appId = meta.attr('content')[1]
         } else {
-            this.appId = /app-id=([^\s,]+)/.exec(meta.attr('content'))[1]
+            // Try to pull the appId out of the meta tag and store the result
+            var parsedMetaContent = /app-id=([^\s,]+)/.exec(meta.attr('content'));
+
+            if(parsedMetaContent) {
+              this.appId = parsedTagContent[1];
+            } else {
+              return;
+            }
         }
 
         this.title = this.options.title ? this.options.title : meta.data('title') || $('title').text().replace(/\s*[|\-·].*$/, '')

--- a/jquery.smartbanner.js
+++ b/jquery.smartbanner.js
@@ -50,7 +50,7 @@
             var parsedMetaContent = /app-id=([^\s,]+)/.exec(meta.attr('content'));
 
             if(parsedMetaContent) {
-              this.appId = parsedTagContent[1];
+              this.appId = parsedMetaContent[1];
             } else {
               return;
             }


### PR DESCRIPTION
If the content attribute of the meta tag is empty or malformed, then
``/app-id=([^\s,]+)/.exec(meta.attr('content'))`` is going to return ``null`` and
trying to index into ``null`` is a bad time.