### PR TITLE
Margin top fix

### DIFF
--- a/jquery.smartbanner.js
+++ b/jquery.smartbanner.js
@@ -134,7 +134,7 @@
 
             if (this.options.layer) {
                 banner.animate({top: 0, display: 'block'}, this.options.speedIn).addClass('shown').show();
-                $('.wrapper').animate({paddingTop: this.origHtmlMargin + (this.bannerHeight * this.scale)}, this.options.speedIn, 'swing', callback);
+                $(this.pushSelector).animate({paddingTop: this.origHtmlMargin + (this.bannerHeight * this.scale)}, this.options.speedIn, 'swing', callback);
             } else {
                 if ($.support.transition) {
                     banner.animate({top:0},this.options.speedIn).addClass('shown');
@@ -144,7 +144,7 @@
                             callback();
                         }
                     };
-                    $('.wrapper').addClass('sb-animation').one($.support.transition.end, transitionCallback).emulateTransitionEnd(this.options.speedIn).css('margin-top', this.origHtmlMargin+(this.bannerHeight*this.scale));
+                    $(this.pushSelector).addClass('sb-animation').one($.support.transition.end, transitionCallback).emulateTransitionEnd(this.options.speedIn).css('margin-top', this.origHtmlMargin+(this.bannerHeight*this.scale));
                 } else {
                     banner.slideDown(this.options.speedIn).addClass('shown');
                 }
@@ -157,7 +157,7 @@
 
             if (this.options.layer) {
                 banner.animate({top: -1 * this.bannerHeight * this.scale, display: 'block'}, this.options.speedIn).removeClass('shown');
-                $('.wrapper').animate({paddingTop: this.origHtmlMargin}, this.options.speedIn, 'swing', callback);
+                $(this.pushSelector).animate({paddingTop: this.origHtmlMargin}, this.options.speedIn, 'swing', callback);
             } else {
                 if ($.support.transition) {
                     banner.css('top', -1*this.bannerHeight*this.scale).removeClass('shown');
@@ -167,7 +167,7 @@
                             callback();
                         }
                     };
-                    $('.wrapper').addClass('sb-animation').one($.support.transition.end, transitionCallback).emulateTransitionEnd(this.options.speedOut).css('margin-top', this.origHtmlMargin);
+                    $(this.pushSelector).addClass('sb-animation').one($.support.transition.end, transitionCallback).emulateTransitionEnd(this.options.speedOut).css('margin-top', this.origHtmlMargin);
                 } else {
                     banner.slideUp(this.options.speedOut).removeClass('shown');
                 }
@@ -255,7 +255,8 @@
         hideOnInstall: true, // Hide the banner after "VIEW" is clicked.
         layer: false, // Display as overlay layer or slide down the page
         iOSUniversalApp: true, // If the iOS App is a universal app for both iPad and iPhone, display Smart Banner to iPad users, too.
-        appendToSelector: 'body' //Append the banner to a specific selector
+        appendToSelector: 'body', //Append the banner to a specific selector
+		pushSelector: 'html' // What element is going to push the site content down; this is where the banner append animation will start.
     }
 
     $.smartbanner.Constructor = SmartBanner;

--- a/jquery.smartbanner.js
+++ b/jquery.smartbanner.js
@@ -134,7 +134,7 @@
 
             if (this.options.layer) {
                 banner.animate({top: 0, display: 'block'}, this.options.speedIn).addClass('shown').show();
-                $('html').animate({marginTop: this.origHtmlMargin + (this.bannerHeight * this.scale)}, this.options.speedIn, 'swing', callback);
+                $('.wrapper').animate({paddingTop: this.origHtmlMargin + (this.bannerHeight * this.scale)}, this.options.speedIn, 'swing', callback);
             } else {
                 if ($.support.transition) {
                     banner.animate({top:0},this.options.speedIn).addClass('shown');
@@ -144,7 +144,7 @@
                             callback();
                         }
                     };
-                    $('html').addClass('sb-animation').one($.support.transition.end, transitionCallback).emulateTransitionEnd(this.options.speedIn).css('margin-top', this.origHtmlMargin+(this.bannerHeight*this.scale));
+                    $('.wrapper').addClass('sb-animation').one($.support.transition.end, transitionCallback).emulateTransitionEnd(this.options.speedIn).css('margin-top', this.origHtmlMargin+(this.bannerHeight*this.scale));
                 } else {
                     banner.slideDown(this.options.speedIn).addClass('shown');
                 }
@@ -157,7 +157,7 @@
 
             if (this.options.layer) {
                 banner.animate({top: -1 * this.bannerHeight * this.scale, display: 'block'}, this.options.speedIn).removeClass('shown');
-                $('html').animate({marginTop: this.origHtmlMargin}, this.options.speedIn, 'swing', callback);
+                $('.wrapper').animate({paddingTop: this.origHtmlMargin}, this.options.speedIn, 'swing', callback);
             } else {
                 if ($.support.transition) {
                     banner.css('top', -1*this.bannerHeight*this.scale).removeClass('shown');
@@ -167,7 +167,7 @@
                             callback();
                         }
                     };
-                    $('html').addClass('sb-animation').one($.support.transition.end, transitionCallback).emulateTransitionEnd(this.options.speedOut).css('margin-top', this.origHtmlMargin);
+                    $('.wrapper').addClass('sb-animation').one($.support.transition.end, transitionCallback).emulateTransitionEnd(this.options.speedOut).css('margin-top', this.origHtmlMargin);
                 } else {
                     banner.slideUp(this.options.speedOut).removeClass('shown');
                 }


### PR DESCRIPTION
This pull request is for the 80px gap issue we were experiencing with our web site when using the jquery.smartbanner plugin. I've attached 3 screenshots of mobile browsers that expose the white gap at the top of the browser window. I've added another selector to the defaults and set it to what was originally being used for the animate() method (ie. html). We needed a different selector class called .wrapper, so we pass that into the plugin initialization to override the default 'html' selector.

![smartbanner-galaxy-s3-chrome-browser](https://cloud.githubusercontent.com/assets/1653971/6216482/ff26e842-b5c7-11e4-8a9e-07fccdb5517d.png)
![smartbanner-kindle-silk-browser](https://cloud.githubusercontent.com/assets/1653971/6216481/ff2623c6-b5c7-11e4-9ba2-6f20783a77cc.png)
![smartbanner-nexus7-chrome-browser](https://cloud.githubusercontent.com/assets/1653971/6216480/ff25e19a-b5c7-11e4-80a5-cdf8f52fa6cf.png)
