### PR TITLE
Added trailing comma to example config parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ brings this feature to older iOS versions, Android devices and for Windows Store
       force: null, // Choose 'ios', 'android' or 'windows'. Don't do a browser check, just always show this banner
       hideOnInstall: true, // Hide the banner after "VIEW" is clicked.
       layer: false, // Display as overlay layer or slide down the page
-      iOSUniversalApp: true // If the iOS App is a universal app for both iPad and iPhone, display Smart Banner to iPad users, too.      
+      iOSUniversalApp: true, // If the iOS App is a universal app for both iPad and iPhone, display Smart Banner to iPad users, too.      
       appendToSelector: 'body' //Append the banner to a specific selector
     })
 


### PR DESCRIPTION
In case anyone copies and pastes the example config params, the trailing comma is required.