### PR TITLE
Added the option to specify the platforms where smart banner is shown

### DIFF
--- a/jquery.smartbanner.js
+++ b/jquery.smartbanner.js
@@ -27,7 +27,7 @@
         }
 
         // Don't show banner if device isn't iOS or Android, website is loaded in app or user dismissed banner
-        if (!this.type || standalone || this.getCookie('sb-closed') || this.getCookie('sb-installed')) {
+        if (!this.type || $.inArray(this.type, this.options.platforms) === -1 || standalone || this.getCookie('sb-closed') || this.getCookie('sb-installed')) {
             return
         }
 
@@ -274,7 +274,8 @@
         layer: false, // Display as overlay layer or slide down the page
         iOSUniversalApp: true, // If the iOS App is a universal app for both iPad and iPhone, display Smart Banner to iPad users, too.
         appendToSelector: 'body', //Append the banner to a specific selector
-		pushSelector: 'html' // What element is going to push the site content down; this is where the banner append animation will start.
+	pushSelector: 'html', // What element is going to push the site content down; this is where the banner append animation will start.
+	platforms: ['ios', 'android', 'windows', 'kindle'] // The platforms where the Smart banner will be displayed
     }
 
     $.smartbanner.Constructor = SmartBanner;


### PR DESCRIPTION
Sometimes, you only want to show the Smart banner on specific devices and not show them on others e.g. I want to show the banner on iOS and Android but not on Windows or Kindle platforms. I can specify that as an option and then I won't see the Smart banner on other supported platforms.

Example:

$.smartbanner({
        platforms: ['ios', 'android']
});