### PR TITLE
Bower and AMD

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "jquery.smartbanner",
+  "main": "jquery.smartbanner.js",
+  "version": "1.0.0",
+  "homepage": "http://jasny.github.com/jquery.smartbanner",
+  "authors": [
+    "Arnold Daniels <arnold@jasny.net>"
+  ],
+  "description": "Smart Banner support for iOS 4/5 and Android",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+	"dependencies": {
+		"jquery": "~1||~2"
+	}
+}

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,9 @@
   "authors": [
     "Arnold Daniels <arnold@jasny.net>"
   ],
+	"moduleType": [
+		"amd"
+	],
   "description": "Smart Banner support for iOS 4/5 and Android",
   "license": "MIT",
   "ignore": [

--- a/jquery.smartbanner.js
+++ b/jquery.smartbanner.js
@@ -3,7 +3,13 @@
  * Copyright (c) 2012 Arnold Daniels <arnold@jasny.net>
  * Based on 'jQuery Smart Web App Banner' by Kurt Zenisek @ kzeni.com
  */
-!function ($) {
+!function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['jquery'], factory);
+  } else {
+    factory(root.jQuery);
+  }
+}(this, function($) {
     var SmartBanner = function (options) {
         this.origHtmlMargin = parseFloat($('html').css('margin-top')) // Get the original margin-top of the HTML element so we can take that into account
         this.options = $.extend({}, $.smartbanner.defaults, options)
@@ -325,4 +331,4 @@
     })
     // ============================================================
 
-}(window.jQuery);
+});


### PR DESCRIPTION
This is a merge of #111 and #107, properly declaring AMD support in `bower.json`.