### PR TITLE
Issue Fixed - Hidden Banner Not Shown

### DIFF
--- a/jquery.smartbanner.js
+++ b/jquery.smartbanner.js
@@ -156,7 +156,7 @@
                 $(this.pushSelector).animate({paddingTop: this.origHtmlMargin + (this.bannerHeight * this.scale)}, this.options.speedIn, 'swing', callback);
             } else {
                 if ($.support.transition) {
-                    banner.animate({top:0},this.options.speedIn).addClass('shown');
+                    banner.animate({top:0},this.options.speedIn).addClass('shown').show();
                     var transitionCallback = function () {
                         $('html').removeClass('sb-animation');
                         if (callback) {


### PR DESCRIPTION
I fixed an issue where the banner was not able to be shown again to the user after it is hidden. 

For example, if the user is typing, a developer can call the function
```
$(window).data('smartbanner').hide();
```
to hide the banner so that the user has more room to type. Once the user is finished typing, the developer can call the function
```
$(window).data('smartbanner').show();
```
to show the banner again. However, there was a bug in the show() function where the banner is not actually displayed to the user a second time. I have fixed the bug via calling the jQuery show() function after the banner animation. 

Thanks,
Shahzore