### PR TITLE
[#99] Fix hide event for smartbanners which option.layer is false (iO…

### DIFF
--- a/jquery.smartbanner.js
+++ b/jquery.smartbanner.js
@@ -281,7 +281,7 @@
         if ($.support.transition) {
           if (this.type !== 'android') {
             banner
-              .css('top', -1 * this.bannerHeight * this.scale)
+              .animate({marginTop: -1 * this.bannerHeight * this.scale}, this.options.speedOut, 'swing', callback)
               .removeClass('shown');
           }
           else {


### PR DESCRIPTION
Default option for layer is false.  And as commented in issue #99, problem is in this string: 

```
      $('#smartbanner')
        .css('position', this.options.layer ? 'absolute' : 'static');
```

Solution for me is animate or margin-top.
