### PR TITLE
Fix for iPhone devices 6 and 6+

### DIFF
--- a/jquery.smartbanner.js
+++ b/jquery.smartbanner.js
@@ -29,11 +29,7 @@
       this.type = 'windows';
     }
     else if (UA.match(/iPhone|iPod/i) !== null || (UA.match(/iPad/) && this.options.iOSUniversalApp)) {
-      if (UA.match(/Safari/i) !== null &&
-          (UA.match(/CriOS/i) !== null ||
-           UA.match(/FxiOS/i) != null ||
-            window.Number(UA.substr(UA.indexOf('OS ') + 3, 3).replace('_', '.')) < 6)) {
-        // Check webview and native smart banner support (iOS 6+).
+      if (UA.match(/Safari/i) !== null) {
         this.type = 'ios';
       }
     }


### PR DESCRIPTION
#### Description:

* iPhone devices are reporting:
"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1" 

when UA is retrieved, so just asking for Safari will do. We don't want the user to open chrome on an iPhone and get sent to the Android PlayStore

---